### PR TITLE
Empty section means back to global

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,6 @@ on:
     branches: [ main ]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
@@ -15,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.21
+        go-version: 1.22
     - name: Lint
       run: go vet ./...
     - name: Build

--- a/tinyini.go
+++ b/tinyini.go
@@ -35,7 +35,7 @@ type Pair struct {
 }
 
 var matchercomment = regexp.MustCompile(`^\s*;`)
-var matchersection = regexp.MustCompile(`^\s*\[(.+?)\]`)
+var matchersection = regexp.MustCompile(`^\s*\[(.*?)\]`)
 var matcherkeyval = regexp.MustCompile(`^\s*(.+?)\s*=\s*(.*?)\s*(;.*)?$`)
 var matcherkeyvalq = regexp.MustCompile(`^\s*(.+?)\s*=\s*"((\\.|[^"\\])*)"\s*(;.*)?$`)
 var matcherempty = regexp.MustCompile(`^\s*$`)

--- a/tinyini_test.go
+++ b/tinyini_test.go
@@ -206,6 +206,41 @@ section2var=notseen
 	})
 }
 
+func TestEmptySection(t *testing.T) {
+	config := `
+main1 = value1
+
+[section]
+subkey=subval
+
+[]
+main2=value2
+
+[another-section]
+another-key=another-value
+`
+	sections, errs := ti.Parse(strings.NewReader(config))
+	if len(errs) != 0 {
+		t.Error(errs)
+	}
+	if !reflect.DeepEqual(
+		sections,
+		ti.Sections{
+			"": ti.Section{
+				"main1": []ti.Pair{ti.Pair{"value1", 2}},
+				"main2": []ti.Pair{ti.Pair{"value2", 8}},
+			},
+			"section": ti.Section{
+				"subkey": []ti.Pair{ti.Pair{"subval", 5}},
+			},
+			"another-section": ti.Section{
+				"another-key": []ti.Pair{ti.Pair{"another-value", 11}},
+			},
+		}) {
+		t.Errorf("bad values, got %#v", sections)
+	}
+}
+
 func ExampleSections() {
 	config := `
 value=123


### PR DESCRIPTION
This permits easier programmatic generation of tinyini configuration files.